### PR TITLE
Unshadow test_inlineCallbacks

### DIFF
--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -88,7 +88,7 @@ def test_succeed(foo):
     assert outcomes.get("failed") == 1
 
 
-def test_inlineCallbacks(testdir):
+def test_twisted_greenlet(testdir):
     testdir.makepyfile("""
 import pytest, greenlet
 


### PR DESCRIPTION
There are two functions named `test_inlineCallbacks` in this file. The second doesn't test `inlineCallbacks`, it tests the `twisted_greenlet` fixture. I think the effect of the name being shadowed is that only the second test is currently being run.

(I confess to not having tested this change.)