### PR TITLE
Extract the twisted greenlet initialization to a separate function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "2.6"
+
+install:
+  - pip install tox
+  - export TOX_ENV=`tox --listenvs | grep "py${TRAVIS_PYTHON_VERSION/./}" | tr '\n' ','`
+
+script: tox -e $TOX_ENV

--- a/pytest_twisted/plugin.py
+++ b/pytest_twisted/plugin.py
@@ -33,7 +33,19 @@ def inlineCallbacks(fun, *args, **kw):
 
 
 def pytest_namespace():
-    return dict(inlineCallbacks=inlineCallbacks, blockon=blockon)
+    return dict(
+        inlineCallbacks=inlineCallbacks,
+        blockon=blockon,
+        init_twisted_greenlet=init_twisted_greenlet
+    )
+
+
+def init_twisted_greenlet():
+    global gr_twisted
+    if not gr_twisted:
+        gr_twisted = greenlet.greenlet(reactor.run)
+        failure.Failure.cleanFailure = lambda self: None  # give me better tracebacks
+    return gr_twisted
 
 
 def stop_twisted_greenlet():
@@ -44,11 +56,8 @@ def stop_twisted_greenlet():
 
 @pytest.fixture(scope="session", autouse=True)
 def twisted_greenlet(request):
-    global gr_twisted
-    gr_twisted = greenlet.greenlet(reactor.run)
-    failure.Failure.cleanFailure = lambda self: None  # give me better tracebacks
     request.addfinalizer(stop_twisted_greenlet)
-    return gr_twisted
+    return init_twisted_greenlet()
 
 
 def _pytest_pyfunc_call(pyfuncitem):

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,13 @@ deps=pytest
 commands=py.test []
 sitepackages=False
 
+[testenv:py26]
+deps=pytest<3.3
+     greenlet
+     twisted<15.5
+commands=py.test []
+sitepackages=False
+
 [testenv:py25]
 deps=pytest
      greenlet


### PR DESCRIPTION
Add an ability to use the plugin functionality in pytest hooks.

Example of usage:
```python
import pytest

pytest_plugins = "pytest_twisted"

def pytest_configure(config):
    pytest.init_twisted_greenlet()
    ...
```
The similar stuff was requested in this issue #8. Additionally, I added config for running tests at travis-ci.

@schmir, @christianmlong Could you help me with this pr, please?