### PR TITLE
Update to not require use of the pytest_namespace() hook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,22 +34,22 @@ inlineCallbacks
 =================
 Using `twisted.internet.defer.inlineCallbacks` as a decorator for test
 functions, which take funcargs, does not work. Please use
-`pytest.inlineCallbacks` instead::
+`pytest_twisted.inlineCallbacks` instead::
 
-  @pytest.inlineCallbacks
+  @pytest_twisted.inlineCallbacks
   def test_some_stuff(tmpdir):
       res = yield threads.deferToThread(os.listdir, tmpdir.strpath)
       assert res == []
 
 Waiting for deferreds in fixtures
 =================================
-`pytest.blockon` allows fixtures to wait for deferreds::
+`pytest_twisted.blockon` allows fixtures to wait for deferreds::
 
   @pytest.fixture
   def val():
       d = defer.Deferred()
       reactor.callLater(1.0, d.callback, 10)
-      return pytest.blockon(d)
+      return pytest_twisted.blockon(d)
 
 
 The twisted greenlet

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -108,7 +108,6 @@ def test_twisted_greenlet(testdir):
 
 def test_blocon_in_hook(testdir):
     testdir.makeconftest("""
-        import pytest
         import pytest_twisted as pt
         from twisted.internet import reactor, defer
 

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -133,19 +133,19 @@ def test_blocon_in_hook(testdir):
 def test_pytest_from_reactor_thread(testdir):
     testdir.makepyfile("""
         import pytest
-        import pytest_twisted as pt
+        import pytest_twisted
         from twisted.internet import reactor, defer
 
         @pytest.fixture
         def fix():
             d = defer.Deferred()
             reactor.callLater(0.01, d.callback, 42)
-            return pt.blockon(d)
+            return pytest_twisted.blockon(d)
 
         def test_simple(fix):
             assert fix == 42
 
-        @pt.inlineCallbacks
+        @pytest_twisted.inlineCallbacks
         def test_fail():
             d = defer.Deferred()
             reactor.callLater(0.01, d.callback, 1)

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -63,6 +63,7 @@ def test_inlineCallbacks(testdir):
     testdir.makepyfile("""
         from twisted.internet import reactor, defer
         import pytest
+        import pytest_twisted
 
         @pytest.fixture(scope="module",
                         params=["fs", "imap", "web"])
@@ -70,7 +71,7 @@ def test_inlineCallbacks(testdir):
             return request.param
 
 
-        @pytest.inlineCallbacks
+        @pytest_twisted.inlineCallbacks
         def test_succeed(foo):
             yield defer.succeed(foo)
             if foo == "web":
@@ -108,12 +109,13 @@ def test_twisted_greenlet(testdir):
 def test_blocon_in_hook(testdir):
     testdir.makeconftest("""
         import pytest
+        import pytest_twisted as pt
         from twisted.internet import reactor, defer
 
         def pytest_configure(config):
             d = defer.Deferred()
             reactor.callLater(0.01, d.callback, 1)
-            pytest.blockon(d)
+            pt.blockon(d)
     """)
     testdir.makepyfile("""
         from twisted.internet import reactor, defer
@@ -131,18 +133,19 @@ def test_blocon_in_hook(testdir):
 def test_pytest_from_reactor_thread(testdir):
     testdir.makepyfile("""
         import pytest
+        import pytest_twisted as pt
         from twisted.internet import reactor, defer
 
         @pytest.fixture
         def fix():
             d = defer.Deferred()
             reactor.callLater(0.01, d.callback, 42)
-            return pytest.blockon(d)
+            return pt.blockon(d)
 
         def test_simple(fix):
             assert fix == 42
 
-        @pytest.inlineCallbacks
+        @pt.inlineCallbacks
         def test_fail():
             d = defer.Deferred()
             reactor.callLater(0.01, d.callback, 1)


### PR DESCRIPTION
pytest 3.3.0 deprecated the use of the pytest_namespace() hook.

https://docs.pytest.org/en/latest/changelog.html#id63