### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "2.6"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 pytest-twisted - test twisted code with pytest
 ==============================================================================
 
-|PyPI| |Pythons| |Travis|_ |AppVeyor|_
+|PyPI| |Pythons| |Travis| |AppVeyor|
 
 :Authors: Ralf Schmitt, Kyle Altendorf, Victor Titor
 :Version: 1.7.1
@@ -89,17 +89,19 @@ That's all.
 
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/pytest-twisted.svg
-    :target: https://pypi.python.org/pypi/pytest-twisted
+   :alt: PyPI version
+   :target: https://pypi.python.org/pypi/pytest-twisted
 
 .. |Pythons| image:: https://img.shields.io/pypi/pyversions/pytest-twisted.svg
-   :alt: supported Python versions
+   :alt: Supported Python versions
+   :target: https://pypi.python.org/pypi/pytest-twisted
 
 .. |Travis| image:: https://travis-ci.org/pytest-dev/pytest-twisted.svg?branch=master
    :alt: Travis build status
-.. _Travis: https://travis-ci.org/pytest-dev/pytest-twisted
+   :target: https://travis-ci.org/pytest-dev/pytest-twisted
 
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/us5l0l9p7hyp2k6x/branch/master?svg=true
    :alt: AppVeyor build status
-.. _AppVeyor: https://ci.appveyor.com/project/vtitor/pytest-twisted
+   :target: https://ci.appveyor.com/project/vtitor/pytest-twisted
 
 .. _guide: CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 pytest-twisted - test twisted code with pytest
 ==============================================================================
 
-|Travis|_ |AppVeyor|_ |Pythons|
+|PyPI| |Pythons| |Travis|_ |AppVeyor|_
 
 :Authors: Ralf Schmitt, Kyle Altendorf, Victor Titor
 :Version: 1.7.1
@@ -88,6 +88,12 @@ corotwine work with pytest-twisted::
 That's all.
 
 
+.. |PyPI| image:: https://img.shields.io/pypi/v/pytest-twisted.svg
+    :target: https://pypi.python.org/pypi/pytest-twisted
+
+.. |Pythons| image:: https://img.shields.io/pypi/pyversions/pytest-twisted.svg
+   :alt: supported Python versions
+
 .. |Travis| image:: https://travis-ci.org/pytest-dev/pytest-twisted.svg?branch=master
    :alt: Travis build status
 .. _Travis: https://travis-ci.org/pytest-dev/pytest-twisted
@@ -95,8 +101,5 @@ That's all.
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/us5l0l9p7hyp2k6x/branch/master?svg=true
    :alt: AppVeyor build status
 .. _AppVeyor: https://ci.appveyor.com/project/vtitor/pytest-twisted
-
-.. |Pythons| image:: https://img.shields.io/pypi/pyversions/pytest-twisted.svg
-   :alt: supported Python versions
 
 .. _guide: CONTRIBUTING.rst

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,6 @@ environment:
   VENV: "%APPVEYOR_BUILD_FOLDER%\\venv"
 
   matrix:
-    - TOXENV: py26
-      PYTHON: "C:\\Python26"
-
-    - TOXENV: py26
-      PYTHON: "C:\\Python26-x64"
-
     - TOXENV: py27
       PYTHON: "C:\\Python27"
 

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -172,7 +172,7 @@ def _install_reactor(reactor_installer, reactor_type):
         import twisted.internet.reactor
         if not isinstance(twisted.internet.reactor, reactor_type):
             raise WrongReactorAlreadyInstalledError(
-                'expected {0} but found {1}'.format(
+                'expected {} but found {}'.format(
                     reactor_type,
                     type(twisted.internet.reactor),
                 )

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -23,7 +23,7 @@ class _instances:
 
 
 def pytest_namespace():
-    return dict(inlineCallbacks=inlineCallbacks, blockon=blockon)
+    return {'inlineCallbacks': inlineCallbacks, 'blockon': blockon}
 
 
 def blockon(d):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -22,9 +22,9 @@ def format_run_result_output_for_assert(run_result):
     return textwrap.dedent('''\
 
         ---- stdout
-        {0}
+        {}
         ---- stderr
-        {1}
+        {}
         ----''').format(
         run_result.stdout.str(),
         run_result.stderr.str(),
@@ -35,7 +35,7 @@ def skip_if_reactor_not(expected_reactor):
     actual_reactor = pytest.config.getoption('reactor')
     return pytest.mark.skipif(
         actual_reactor != expected_reactor,
-        reason='reactor is {0} not {1}'.format(
+        reason='reactor is {} not {}'.format(
             actual_reactor,
             expected_reactor,
         ),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{26,27,34}-defaultreactor
+    py{27,34}-defaultreactor
     py{35,36}-{default,qt5}reactor
     linting
 
@@ -8,9 +8,7 @@ envlist=
 [testenv]
 deps=
     greenlet
-    py26: pytest<3.3
     py{27,34,35,36}: pytest
-    py26: twisted<15.5
     py{27,34,35,36}: twisted
     qt5reactor: pytest-qt
     qt5reactor: qt5reactor

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ envlist=
 [testenv]
 deps=
     greenlet
-    py{27,34,35,36}: pytest
-    py{27,34,35,36}: twisted
+    pytest
+    twisted
     qt5reactor: pytest-qt
     qt5reactor: qt5reactor
     qt5reactor: pytest-xvfb


### PR DESCRIPTION
pytest itself has already dropped support for Python 2.6 (in https://github.com/pytest-dev/pytest/issues/2812) as it's been EOL for over four years.

This drops support for Python 2.6 and updates some code to make use of new Python 2.7+ features.