### PR TITLE
[35] Support async/await fixtures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ async/await fixtures
 ``async``/``await`` fixtures can be used along with ``yield`` for normal
 pytest fixture semantics of setup, value, and teardown.
 
-  @pytest.fixture
+  @pytest_twisted.async_fixture
   async def foo():
       d1, d2 = defer.Deferred(), defer.Deferred()
       reactor.callLater(0.01, d1.callback, 42)

--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,21 @@ Waiting for deferreds in fixtures
       return pytest_twisted.blockon(d)
 
 
+async/await fixtures
+====================
+``async``/``await`` fixtures can be used along with ``yield`` for normal
+pytest fixture semantics of setup, value teardown.
+
+  @pytest.fixture
+  async def foo():
+      d1, d2 = defer.Deferred(), defer.Deferred()
+      reactor.callLater(0.01, d1.callback, 42)
+      reactor.callLater(0.02, d2.callback, 37)
+      value = await d1
+      yield value
+      await d2
+
+
 The twisted greenlet
 ====================
 Some libraries (e.g. corotwine) need to know the greenlet, which is

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Waiting for deferreds in fixtures
 async/await fixtures
 ====================
 ``async``/``await`` fixtures can be used along with ``yield`` for normal
-pytest fixture semantics of setup, value teardown.
+pytest fixture semantics of setup, value, and teardown.
 
   @pytest.fixture
   async def foo():

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,8 @@ Waiting for deferreds in fixtures
 async/await fixtures
 ====================
 ``async``/``await`` fixtures can be used along with ``yield`` for normal
-pytest fixture semantics of setup, value, and teardown.
+pytest fixture semantics of setup, value, and teardown.  At present only
+function scope is supported.
 
   @pytest_twisted.async_fixture
   async def foo():

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ async/await fixtures
 ====================
 ``async``/``await`` fixtures can be used along with ``yield`` for normal
 pytest fixture semantics of setup, value, and teardown.  At present only
-function scope is supported.
+function scope is supported::
 
   @pytest_twisted.async_fixture
   async def foo():

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -22,6 +22,14 @@ class UnrecognizedCoroutineMarkError(Exception):
         )
 
 
+class AsyncGeneratorFixtureDidNotStopError(Exception):
+    @classmethod
+    def from_generator(cls, generator):
+        return cls(
+            'async fixture did not stop: {}'.format(generator),
+        )
+
+
 class _config:
     external_reactor = False
 
@@ -172,8 +180,8 @@ def _pytest_pyfunc_call(pyfuncitem):
             except StopAsyncIteration:
                 continue
             else:
-                raise RuntimeError(
-                    'async fixture did not stop: {}'.format(arg),
+                raise AsyncGeneratorFixtureDidNotStopError.from_generator(
+                    generator=arg,
                 )
 
         defer.returnValue(result)

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -1,7 +1,10 @@
 import inspect
 import sys
 
+# https://docs.python.org/3/whatsnew/3.5.html#pep-492-coroutines-with-async-and-await-syntax
 ASYNC_AWAIT = sys.version_info >= (3, 5)
+
+# https://docs.python.org/3/whatsnew/3.6.html#pep-525-asynchronous-generators
 ASYNC_GENERATORS = sys.version_info >= (3, 6)
 
 if ASYNC_AWAIT:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -131,11 +131,14 @@ def _pytest_pyfunc_call(pyfuncitem):
             testargs = funcargs
         result = yield testfunction(**testargs)
 
-        for async_generator in async_generators:
+        async_generator_deferreds = [
+            defer.ensureDeferred(g.__anext__())
+            for g in async_generators
+        ]
+
+        for d in async_generator_deferreds:
             try:
-                yield defer.ensureDeferred(
-                    async_generator.__anext__(),
-                )
+                yield d
             except StopAsyncIteration:
                 continue
             else:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -149,14 +149,8 @@ def pytest_pyfunc_call(pyfuncitem):
         if _instances.gr_twisted.dead:
             raise RuntimeError("twisted reactor has stopped")
 
-        @defer.inlineCallbacks
         def in_reactor(d, f, *args):
-            try:
-                result = yield f(*args)
-            except Exception as e:
-                d.callback(failure.Failure(e))
-            else:
-                d.callback(result)
+            return defer.maybeDeferred(f, *args).chainDeferred(d)
 
         d = defer.Deferred()
         _instances.reactor.callLater(

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -8,11 +8,6 @@ ASYNC_AWAIT = sys.version_info >= (3, 5)
 # https://docs.python.org/3/whatsnew/3.6.html#pep-525-asynchronous-generators
 ASYNC_GENERATORS = sys.version_info >= (3, 6)
 
-if ASYNC_AWAIT:
-    import asyncio
-else:
-    asyncio = None
-
 
 import decorator
 import greenlet

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -171,7 +171,7 @@ def _pytest_pyfunc_call(pyfuncitem):
 
         async_generator_deferreds = [
             (arg, defer.ensureDeferred(g.coroutine.__anext__()))
-            for arg, g in async_generators
+            for arg, g in reversed(async_generators)
         ]
 
         for arg, d in async_generator_deferreds:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -100,6 +100,7 @@ class _CoroutineWrapper:
 
 
 def _marked_async_fixture(mark):
+    @functools.wraps(pytest.fixture)
     def fixture(*args, **kwargs):
         def marker(f):
             @functools.wraps(f)

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -1,13 +1,5 @@
 import functools
 import inspect
-import sys
-
-# https://docs.python.org/3/whatsnew/3.5.html#pep-492-coroutines-with-async-and-await-syntax
-ASYNC_AWAIT = sys.version_info >= (3, 5)
-
-# https://docs.python.org/3/whatsnew/3.6.html#pep-525-asynchronous-generators
-ASYNC_GENERATORS = sys.version_info >= (3, 6)
-
 
 import decorator
 import greenlet

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -224,6 +224,9 @@ def test_async_fixture_yield(testdir, cmd_opts):
         reactor.callLater(0.02, d2.callback, request.param)
         await d1
 
+        # Twisted doesn't allow calling back with a Deferred as a value.
+        # This deferred is being wrapped up in a tuple to sneak through.
+        # https://github.com/twisted/twisted/blob/c0f1394c7bfb04d97c725a353a1f678fa6a1c602/src/twisted/internet/defer.py#L459
         yield d2,
 
         if request.param == "gopher":

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -207,7 +207,7 @@ def test_async_fixture(testdir, cmd_opts):
     assert_outcomes(rr, {"passed": 2, "failed": 1})
 
 
-@skip_if_no_async_await()
+@skip_if_no_async_generators()
 def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
     test_file = """
     import time

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -342,7 +342,7 @@ def test_async_fixture(testdir, cmd_opts):
 
 
 @skip_if_no_async_generators()
-def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
+def test_async_yield_fixture_concurrent_teardown(testdir, cmd_opts):
     test_file = """
     from twisted.internet import reactor, defer
     import pytest
@@ -379,7 +379,7 @@ def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
 
 
 @skip_if_no_async_generators()
-def test_async_fixture_yield(testdir, cmd_opts):
+def test_async_yield_fixture(testdir, cmd_opts):
     test_file = """
     from twisted.internet import reactor, defer
     import pytest
@@ -418,7 +418,7 @@ def test_async_fixture_yield(testdir, cmd_opts):
 
 
 @skip_if_no_async_generators()
-def test_async_fixture_function_scope(testdir, cmd_opts):
+def test_async_yield_fixture_function_scope(testdir, cmd_opts):
     test_file = """
     from twisted.internet import reactor, defer
     import pytest

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -6,6 +6,13 @@ import pytest
 import pytest_twisted
 
 
+# https://docs.python.org/3/whatsnew/3.5.html#pep-492-coroutines-with-async-and-await-syntax
+ASYNC_AWAIT = sys.version_info >= (3, 5)
+
+# https://docs.python.org/3/whatsnew/3.6.html#pep-525-asynchronous-generators
+ASYNC_GENERATORS = sys.version_info >= (3, 6)
+
+
 def assert_outcomes(run_result, outcomes):
     formatted_output = format_run_result_output_for_assert(run_result)
 
@@ -39,14 +46,14 @@ def skip_if_reactor_not(request, expected_reactor):
 
 def skip_if_no_async_await():
     return pytest.mark.skipif(
-        not pytest_twisted.ASYNC_AWAIT,
+        not ASYNC_AWAIT,
         reason="async/await syntax not support on Python <3.5",
     )
 
 
 def skip_if_no_async_generators():
     return pytest.mark.skipif(
-        not pytest_twisted.ASYNC_GENERATORS,
+        not ASYNC_GENERATORS,
         reason="async generators not support on Python <3.6",
     )
 

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -223,6 +223,7 @@ def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
         yield 42
 
         there.callback(None)
+        reactor.callLater(5, here.cancel)
         await here
 
     @pytest.fixture
@@ -230,6 +231,7 @@ def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
         yield 37
 
         here.callback(None)
+        reactor.callLater(5, there.cancel)
         await there
 
     def test_succeed(this, that):

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -199,7 +199,6 @@ def test_async_fixture(testdir, cmd_opts):
     @pytest_twisted.inlineCallbacks
     def test_succeed(foo):
         x = yield foo[0]
-        print('+++', x)
         if x == "web":
             raise RuntimeError("baz")
     """
@@ -236,7 +235,6 @@ def test_async_fixture_yield(testdir, cmd_opts):
     @pytest_twisted.inlineCallbacks
     def test_succeed(foo):
         x = yield foo[0]
-        print('+++', x)
         if x == "web":
             raise RuntimeError("baz")
     """

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -188,7 +188,8 @@ def test_async_fixture(testdir, cmd_opts):
     import pytest
     import pytest_twisted
 
-    @pytest.fixture(scope="function", params=["fs", "imap", "web"])
+    @pytest_twisted.async_fixture(scope="function", params=["fs", "imap", "web"])
+    @pytest.mark.redgreenblue
     async def foo(request):
         d1, d2 = defer.Deferred(), defer.Deferred()
         reactor.callLater(0.01, d1.callback, 1)
@@ -197,7 +198,7 @@ def test_async_fixture(testdir, cmd_opts):
         return d2,
 
     @pytest_twisted.inlineCallbacks
-    def test_succeed(foo):
+    def test_succeed_blue(foo):
         x = yield foo[0]
         if x == "web":
             raise RuntimeError("baz")
@@ -218,7 +219,7 @@ def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
     here = defer.Deferred()
     there = defer.Deferred()
 
-    @pytest.fixture
+    @pytest_twisted.async_yield_fixture()
     async def this():
         yield 42
 
@@ -226,7 +227,7 @@ def test_async_fixture_concurrent_teardown(testdir, cmd_opts):
         reactor.callLater(5, here.cancel)
         await here
 
-    @pytest.fixture
+    @pytest_twisted.async_yield_fixture()
     async def that():
         yield 37
 
@@ -251,7 +252,7 @@ def test_async_fixture_yield(testdir, cmd_opts):
     import pytest
     import pytest_twisted
 
-    @pytest.fixture(
+    @pytest_twisted.async_yield_fixture(
         scope="function",
         params=["fs", "imap", "web", "gopher", "archie"],
     )


### PR DESCRIPTION
Redo of pytest-dev/pytest-twisted#36 but straight off of master

WIP for:
* [x] ~~Actual timeout for concurrent teardown test~~
  * https://github.com/pytest-dev/pytest/issues/4073
  * Handled the timeout internally in b0b623e3453324644d52f1a1b1f354cb6d76f230
* [x] Consideration of requiring decorator for async fixtures
  * I'm tempted to say we should do this.  What with explicit being good and all.
* [x] Self review with a fresh brain
* [ ] ~~Proper ordering of fixture setup and teardown including inter-fixture dependencies~~
  * #57