### PR TITLE
add pytest.ensureDeferred

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,15 @@ Waiting for deferreds in fixtures
       reactor.callLater(1.0, d.callback, 10)
       return pytest_twisted.blockon(d)
 
+Using Python3 coroutines
+========================
+You may use ``pytest_twisted.ensureDeferred`` as a decorator for test
+methods using Python3 ``async def`` coroutines::
+
+  @pytest.ensureDeferred
+  async def test_something():
+      pass
+
 
 The twisted greenlet
 ====================

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -23,7 +23,11 @@ class _instances:
 
 
 def pytest_namespace():
-    return {"inlineCallbacks": inlineCallbacks, "blockon": blockon}
+    return {
+        "inlineCallbacks": inlineCallbacks,
+        "blockon": blockon,
+        "ensureDeferred": ensureDeferred,
+    }
 
 
 def blockon(d):
@@ -63,6 +67,19 @@ def block_from_thread(d):
 @decorator.decorator
 def inlineCallbacks(fun, *args, **kw):
     return defer.inlineCallbacks(fun)(*args, **kw)
+
+
+@decorator.decorator
+def ensureDeferred(fun, *args, **kw):
+    """
+    A version of Twisted's ensureDeferred that can be used as a
+    decorator, e.g. to use co-routines for top-level tests::
+
+        @pytest.ensureDeferred
+        async def test_something(a_fixture):
+            await something_async()
+    """
+    return defer.ensureDeferred(fun(*args, **kw))
 
 
 def init_twisted_greenlet():


### PR DESCRIPTION
This allows one to write Twisted-using `async def` co-routines for tests.