### PR TITLE
Fix double definition of pytest_configure

### DIFF
--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -22,11 +22,6 @@ class _instances:
     reactor = None
 
 
-def pytest_configure():
-    pytest.inlineCallbacks = inlineCallbacks
-    pytest.blockon = blockon
-
-
 def blockon(d):
     if _config.external_reactor:
         return block_from_thread(d)
@@ -185,4 +180,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    pytest.inlineCallbacks = inlineCallbacks
+    pytest.blockon = blockon
     reactor_installers[config.getoption("reactor")]()

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -41,6 +41,14 @@ def cmd_opts(request):
     return ("--reactor={}".format(reactor),)
 
 
+def test_inline_callbacks_in_pytest():
+    assert hasattr(pytest, 'inlineCallbacks')
+
+
+def test_blockon_in_pytest():
+    assert hasattr(pytest, 'blockon')
+
+
 def test_fail_later(testdir, cmd_opts):
     test_file = """
     from twisted.internet import reactor, defer


### PR DESCRIPTION
Currently ``pytest_configure`` is defined twice in ``pytest_twisted.py``, this pull request fixes it, closes #50 .