### PR TITLE
Stop checking for pyfuncitem._isyieldedfunction()

### DIFF
--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -107,17 +107,14 @@ def stop_twisted_greenlet():
 
 def _pytest_pyfunc_call(pyfuncitem):
     testfunction = pyfuncitem.obj
-    if pyfuncitem._isyieldedfunction():
-        return testfunction(*pyfuncitem._args)
+    funcargs = pyfuncitem.funcargs
+    if hasattr(pyfuncitem, "_fixtureinfo"):
+        testargs = {}
+        for arg in pyfuncitem._fixtureinfo.argnames:
+            testargs[arg] = funcargs[arg]
     else:
-        funcargs = pyfuncitem.funcargs
-        if hasattr(pyfuncitem, "_fixtureinfo"):
-            testargs = {}
-            for arg in pyfuncitem._fixtureinfo.argnames:
-                testargs[arg] = funcargs[arg]
-        else:
-            testargs = funcargs
-        return testfunction(**testargs)
+        testargs = funcargs
+    return testfunction(**testargs)
 
 
 def pytest_pyfunc_call(pyfuncitem):

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -3,8 +3,6 @@ import textwrap
 
 import pytest
 
-import pytest_twisted
-
 
 ASYNC_AWAIT = sys.version_info >= (3, 5)
 
@@ -37,7 +35,9 @@ def format_run_result_output_for_assert(run_result):
 def skip_if_reactor_not(request, expected_reactor):
     actual_reactor = request.config.getoption("reactor", "default")
     if actual_reactor != expected_reactor:
-        pytest.skip("reactor is {} not {}".format(actual_reactor, expected_reactor))
+        pytest.skip(
+            "reactor is {} not {}".format(actual_reactor, expected_reactor),
+        )
 
 
 def skip_if_no_async_await():


### PR DESCRIPTION
Removed in pytest v4.4.0.

https://github.com/pytest-dev/pytest/commit/47bd1688ed0da460fc6b1885e82bb9aa5bd1c3e0