### PR TITLE
Distribute license on pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include MANIFEST.in
+include LICENSE
 include README.rst
 include pytest_twisted.py
 include setup.cfg


### PR DESCRIPTION
The license should be distributed with the archive on pypi.