### PR TITLE
Update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 BSD 3-Clause License
 
 Copyright (c) 2012, Ralf Schmitt
+Copyright (c) 2018, Victor Titor
+Copyright (c) 2019-2020, Kyle Altendorf
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I noticed the copyright was still on 2012.

I sure am not a lawyer, so I don't know how this stuff works at all, but it's my belief that a maintainer should be able to claim copyright for a given year if they were the maintainer for the majority of the year. Based on the timelines of #11 and #42, I think adding the following is reasonable:

Copyright (c) 2018, Victor Titor
Copyright (c) 2019-2020, Kyle Altendorf

One outstanding question is what to do about the intervening 2013-2017 (inclusive).

CC: @schmir @vtitor @altendky please tell me what to do :)