### PR TITLE
Add a daily build to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: 
       - "*"
+  schedule:
+    # Daily at 05:47
+    - cron: '47 5 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
This helps discover incompatibilities with new libraries sooner.  Longer term it would be nice to have locked versions to test against as well as testing against latest released dependency versions, `--pre`, and even vcs dependency versions.  This would allow clarity as to what broke a given build while still looking (even farther) ahead to discover incompatibilities early.  For now...  at least check daily.