### PR TITLE
Restructure pytest plugin hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ async/await fixtures
 ====================
 ``async``/``await`` fixtures can be used along with ``yield`` for normal
 pytest fixture semantics of setup, value, and teardown.  At present only
-function scope is supported.
+function and module scope are supported.
 
 Note: You must *call* ``pytest_twisted.async_fixture()`` and
 ``pytest_twisted.async_yield_fixture()``.

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -256,7 +256,7 @@ def _pytest_fixture_setup(fixturedef, request, wrapper):
 
     fixturedef.cached_result = (arg_value, request.param_index, None)
 
-    return arg_value
+    defer.returnValue(arg_value)
 
     # async_generator_deferreds = [
     #     (arg, defer.ensureDeferred(g.coroutine.__anext__()))
@@ -387,8 +387,6 @@ def pytest_runtest_teardown(item):
             # blockingCallFromThread(
             #     _instances.reactor, tear_it_down, deferred
             # )
-
-    return None
 
 
 @defer.inlineCallbacks

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -143,7 +143,9 @@ def _marked_async_fixture(mark):
         except IndexError:
             scope = kwargs.get('scope', 'function')
 
-        if scope != 'function':
+        if scope not in ['function', 'module']:
+            # TODO: add test for session scope (and that's it, right?)
+            #       then remove this and update docs
             raise AsyncFixtureUnsupportedScopeError.from_scope(scope=scope)
 
         def decorator(f):

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -273,7 +273,7 @@ def tear_it_down(deferred):
         yield deferred
     except StopAsyncIteration:
         return
-    except Exception: # as e:
+    except Exception:   # as e:
         pass
         # e = e
     else:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -281,7 +281,6 @@ def pytest_pyfunc_call(pyfuncitem):
     return True
 
 
-# TODO: switch to some plugin callback to guarantee order before other fixtures?
 @pytest.fixture(scope="session", autouse=True)
 def twisted_greenlet(request):
     return _instances.gr_twisted

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -555,6 +555,10 @@ def pytest_configure(config):
     reactor_installers[config.getoption("reactor")]()
 
 
+def pytest_unconfigure(config):
+    stop_twisted_greenlet()
+
+
 def _use_asyncio_selector_if_required(config):
     # https://twistedmatrix.com/trac/ticket/9766
     # https://github.com/pytest-dev/pytest-twisted/issues/80

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -274,9 +274,11 @@ def tear_it_down(deferred):
     except StopAsyncIteration:
         return
     except Exception as e:
-        e = e
+        pass
+        # e = e
     else:
-        e = None
+        pass
+        # e = None
 
     # TODO: six.raise_from()
     raise AsyncGeneratorFixtureDidNotStopError.from_generator(

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -273,7 +273,7 @@ def tear_it_down(deferred):
         yield deferred
     except StopAsyncIteration:
         return
-    except Exception as e:
+    except Exception: # as e:
         pass
         # e = e
     else:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -282,7 +282,7 @@ def pytest_pyfunc_call(pyfuncitem):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def twisted_greenlet(request):
+def twisted_greenlet():
     return _instances.gr_twisted
 
 

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -183,6 +183,8 @@ def _marked_async_fixture(mark):
             #       https://docs.pytest.org/en/latest/reference.html#pytest-fixture-api
             #       then remove this and update docs, or maybe keep it around
             #       in case new options come in without support?
+            #
+            #       https://github.com/pytest-dev/pytest-twisted/issues/56
             raise AsyncFixtureUnsupportedScopeError.from_scope(scope=scope)
 
         def decorator(f):

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -124,10 +124,10 @@ def init_twisted_greenlet():
         _config.external_reactor = True
 
 
-# def stop_twisted_greenlet():
-#     if _instances.gr_twisted:
-#         _instances.reactor.stop()
-#         _instances.gr_twisted.switch()
+def stop_twisted_greenlet():
+    if _instances.gr_twisted:
+        _instances.reactor.stop()
+        _instances.gr_twisted.switch()
 
 
 class _CoroutineWrapper:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -166,7 +166,7 @@ async_yield_fixture = _marked_async_fixture('async_yield_fixture')
 
 def pytest_fixture_setup(fixturedef, request):
     """Interface pytest to async setup for async and async yield fixtures."""
-    # TODO: what about inlineCallbacks fixtures?
+    # TODO: what about _adding_ inlineCallbacks fixture support?
     maybe_mark = getattr(fixturedef.func, _mark_attribute_name, None)
     if maybe_mark is None:
         return None

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -240,7 +240,7 @@ def _async_pytest_fixture_setup(fixturedef, request, mark):
         coroutine = fixture_function(**kwargs)
 
         finalizer = functools.partial(
-            _async_pytest_fixture_finalizer,
+            _async_yield_pytest_fixture_finalizer,
             coroutine=coroutine,
         )
         request.addfinalizer(finalizer)
@@ -256,7 +256,8 @@ def _async_pytest_fixture_setup(fixturedef, request, mark):
     defer.returnValue(arg_value)
 
 
-def _async_pytest_fixture_finalizer(coroutine):
+def _async_yield_pytest_fixture_finalizer(coroutine):
+    """Teardown async yield fixture coroutine."""
     deferred = defer.ensureDeferred(coroutine.__anext__())
     _run_inline_callbacks(tear_it_down, deferred)
 

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -141,13 +141,9 @@ def _marked_async_fixture(mark):
         if scope != 'function':
             raise AsyncFixtureUnsupportedScopeError.from_scope(scope=scope)
 
-        def _mark(f):
-            setattr(f, _mark_attribute_name, mark)
-
-            return f
-
         def decorator(f):
-            result = pytest.fixture(*args, **kwargs)(_mark(f))
+            setattr(f, _mark_attribute_name, mark)
+            result = pytest.fixture(*args, **kwargs)(f)
 
             return result
 

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -109,6 +109,11 @@ def block_from_thread(d):
 
 @decorator.decorator
 def inlineCallbacks(fun, *args, **kw):
+    # TODO: it presumably doesn't matter but i really dislike how this
+    #       creates a new inlineCallbacks for each call.  but, that's
+    #       a pretty irrelevant concern given that 1) it is just a function
+    #       call overhead and 2) lots of tests are only called once anyways.
+    #       but, this gets the feeling out of my head...
     return defer.inlineCallbacks(fun)(*args, **kw)
 
 

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -123,6 +123,11 @@ def inlineCallbacks(f):
     """
     Mark as inline callbacks test for pytest-twisted processing and apply
     @inlineCallbacks.
+
+    Unlike @ensureDeferred, @inlineCallbacks can be applied here because it
+    does not call nor schedule the test function.  Further, @inlineCallbacks
+    must be applied here otherwise pytest identifies the test as a 'yield test'
+    for which they dropped support in 4.0 and now they skip.
     """
     decorated = decorator_apply(defer.inlineCallbacks, f)
     _set_mark(o=decorated, mark='inline_callbacks_test')
@@ -131,7 +136,12 @@ def inlineCallbacks(f):
 
 
 def ensureDeferred(f):
-    """Mark as async test for pytest-twisted processing."""
+    """
+    Mark as async test for pytest-twisted processing.
+
+    Unlike @inlineCallbacks, @ensureDeferred must not be applied here since it
+    would call and schedule the test function.
+    """
     _set_mark(o=f, mark='async_test')
 
     return f

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -434,7 +434,7 @@ def test_async_yield_fixture(testdir, cmd_opts):
         yield d2,
 
         if request.param == "gopher":
-            raise RuntimeError("gaz", request.param)
+            raise RuntimeError("gaz")
 
         if request.param == "archie":
             yield 42

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -890,7 +890,6 @@ def test_async_fixture_module_scope(testdir, cmd_opts):
         assert foo == 42
 
         check_me = 2
-        # check_me += 1
 
     def test_second(foo):
         global check_me
@@ -899,7 +898,6 @@ def test_async_fixture_module_scope(testdir, cmd_opts):
         assert foo == 42
 
         check_me = 3
-        # check_me += 1
     """
     testdir.makepyfile(test_file)
     rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -495,6 +495,64 @@ def test_async_yield_fixture_function_scope(testdir, cmd_opts):
 
 
 @skip_if_no_async_await()
+def test_async_simple_fixture_in_fixture(testdir, cmd_opts):
+    test_file = """
+    import itertools
+    from twisted.internet import reactor, defer
+    import pytest
+    import pytest_twisted
+
+    @pytest_twisted.async_fixture(name='four')
+    async def fixture_four():
+        return 4
+
+    @pytest_twisted.async_fixture(name='doublefour')
+    async def fixture_doublefour(four):
+        return 2 * four
+
+    @pytest_twisted.ensureDeferred
+    async def test_four(four):
+        assert four == 4
+
+    @pytest_twisted.ensureDeferred
+    async def test_doublefour(doublefour):
+        assert doublefour == 8
+    """
+    testdir.makepyfile(test_file)
+    rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
+    assert_outcomes(rr, {"passed": 2})
+
+
+@skip_if_no_async_generators()
+def test_async_yield_simple_fixture_in_fixture(testdir, cmd_opts):
+    test_file = """
+    import itertools
+    from twisted.internet import reactor, defer
+    import pytest
+    import pytest_twisted
+
+    @pytest_twisted.async_yield_fixture(name='four')
+    async def fixture_four():
+        yield 4
+
+    @pytest_twisted.async_yield_fixture(name='doublefour')
+    async def fixture_doublefour(four):
+        yield 2 * four
+
+    @pytest_twisted.ensureDeferred
+    async def test_four(four):
+        assert four == 4
+
+    @pytest_twisted.ensureDeferred
+    async def test_doublefour(doublefour):
+        assert doublefour == 8
+    """
+    testdir.makepyfile(test_file)
+    rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
+    assert_outcomes(rr, {"passed": 2})
+
+
+@skip_if_no_async_await()
 @pytest.mark.parametrize('innerasync', [
     pytest.param(truth, id='innerasync={}'.format(truth))
     for truth in [True, False]

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -30,10 +30,13 @@ def assert_outcomes(run_result, outcomes):
     normalized_outcomes = {
         force_plural(name): outcome
         for name, outcome in result_outcomes.items()
+        if force_plural(name) in outcomes # TODO: do we really only want to check the specified outcomes?
     }
 
-    for name, value in outcomes.items():
-        assert normalized_outcomes.get(name) == value, formatted_output
+    assert normalized_outcomes == outcomes
+
+    # for name, value in outcomes.items():
+    #     assert normalized_outcomes.get(name) == value, formatted_output
 
 
 def format_run_result_output_for_assert(run_result):
@@ -430,11 +433,11 @@ def test_async_yield_fixture(testdir, cmd_opts):
         yield d2,
 
         if request.param == "gopher":
-            raise RuntimeError("gaz")
+            raise RuntimeError("gaz", request.param)
 
         if request.param == "archie":
             yield 42
-
+    
     @pytest_twisted.inlineCallbacks
     def test_succeed(foo):
         x = yield foo[0]
@@ -443,7 +446,8 @@ def test_async_yield_fixture(testdir, cmd_opts):
     """
     testdir.makepyfile(test_file)
     rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
-    assert_outcomes(rr, {"passed": 2, "failed": 3})
+    # TODO: this is getting super imprecise...
+    assert_outcomes(rr, {"passed": 4, "failed": 1, "errors": 2})
 
 
 @skip_if_no_async_generators()
@@ -597,6 +601,7 @@ def test_async_fixture_in_fixture(testdir, cmd_opts, innerasync):
     testdir.makepyfile(test_file)
     rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
     assert_outcomes(rr, {"passed": 2})
+    # assert_outcomes(rr, {"passed": 1})
 
 
 @skip_if_no_async_generators()

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -30,7 +30,8 @@ def assert_outcomes(run_result, outcomes):
     normalized_outcomes = {
         force_plural(name): outcome
         for name, outcome in result_outcomes.items()
-        if force_plural(name) in outcomes # TODO: do we really only want to check the specified outcomes?
+        # TODO: do we really only want to check the specified outcomes?
+        if force_plural(name) in outcomes
     }
 
     assert normalized_outcomes == outcomes
@@ -437,7 +438,7 @@ def test_async_yield_fixture(testdir, cmd_opts):
 
         if request.param == "archie":
             yield 42
-    
+
     @pytest_twisted.inlineCallbacks
     def test_succeed(foo):
         x = yield foo[0]


### PR DESCRIPTION
These changes enable handling of nested async fixtures and non-function scope async fixtures.

WIP for:

- [x] More self review for trivial cleanup
- [x] Self review of architecture
- [x] ~~Matching fixture teardown order~~
  - Presently this PR is coded for concurrent teardown which sounds nice with async but some fixtures will not only have startup dependencies on other fixtures but also teardown dependencies.  This should be able to be documented etc but for now we should probably just skip concurrent teardown.  That said, there's a test for it so... hmm.
  - In another PR add config for this and deprecate the default concurrent teardown.  Or maybe leave it and allow fixture teardown dependency specification.  Or default non-concurrent and ...  do it somewhere else.  #57
- [x] Attempt to get 'external' feedback
- [x] Review and update readme
- [x] Fix outcome assertion #98
- [x] Address loss of concurrent fixture teardown caused by https://github.com/pytest-dev/pytest-twisted/pull/91/commits/50983ee221555208dce508addd4846a6078480c9 and masked by the bad outcome assertions