### PR TITLE
Optional call for decorators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,10 +164,6 @@ async/await fixtures
 pytest fixture semantics of setup, value, and teardown.  At present only
 function and module scope are supported.
 
-Note: You must *call* ``pytest_twisted.async_fixture()`` and
-``pytest_twisted.async_yield_fixture()``.
-This requirement may be removed in a future release.
-
 .. code-block:: python
 
   # No yield (coroutine function)

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -135,7 +135,7 @@ def repr_args_kwargs(*args, **kwargs):
 
 
 def positional_not_allowed_exception(*args, **kwargs):
-    arguments = repr_args_kwargs(**args, **kwargs)
+    arguments = repr_args_kwargs(*args, **kwargs)
 
     return DecoratorArgumentsError(
         'Positional decorator arguments not allowed: {}'.format(arguments),

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -408,7 +408,7 @@ def test_async_fixture_no_arguments(testdir, cmd_opts, empty_optional_call):
         assert scope == "function"
     """.format(optional_call=empty_optional_call)
     testdir.makepyfile(test_file)
-    rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
+    rr = testdir.run(*cmd_opts, timeout=timeout)
     assert_outcomes(rr, {"passed": 1})
 
 
@@ -508,7 +508,7 @@ def test_async_yield_fixture_no_arguments(
         assert scope == "function"
     """.format(optional_call=empty_optional_call)
     testdir.makepyfile(test_file)
-    rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
+    rr = testdir.run(*cmd_opts, timeout=timeout)
     assert_outcomes(rr, {"passed": 1})
 
 

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -226,7 +226,16 @@ def test_exception(testdir, cmd_opts):
     assert_outcomes(rr, {"failed": 1})
 
 
-def test_inlineCallbacks(testdir, cmd_opts):
+@pytest.fixture(
+    name="empty_optional_call",
+    params=["", "()"],
+    ids=["no call", "empty call"],
+)
+def empty_optional_call_fixture(request):
+    return request.param
+
+
+def test_inlineCallbacks(testdir, cmd_opts, empty_optional_call):
     test_file = """
     from twisted.internet import reactor, defer
     import pytest
@@ -236,19 +245,19 @@ def test_inlineCallbacks(testdir, cmd_opts):
     def foo(request):
         return request.param
 
-    @pytest_twisted.inlineCallbacks
+    @pytest_twisted.inlineCallbacks{optional_call}
     def test_succeed(foo):
         yield defer.succeed(foo)
         if foo == "web":
             raise RuntimeError("baz")
-    """
+    """.format(optional_call=empty_optional_call)
     testdir.makepyfile(test_file)
     rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
     assert_outcomes(rr, {"passed": 2, "failed": 1})
 
 
 @skip_if_no_async_await()
-def test_async_await(testdir, cmd_opts):
+def test_async_await(testdir, cmd_opts, empty_optional_call):
     test_file = """
     from twisted.internet import reactor, defer
     import pytest
@@ -258,12 +267,12 @@ def test_async_await(testdir, cmd_opts):
     def foo(request):
         return request.param
 
-    @pytest_twisted.ensureDeferred
+    @pytest_twisted.ensureDeferred{optional_call}
     async def test_succeed(foo):
         await defer.succeed(foo)
         if foo == "web":
             raise RuntimeError("baz")
-    """
+    """.format(optional_call=empty_optional_call)
     testdir.makepyfile(test_file)
     rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
     assert_outcomes(rr, {"passed": 2, "failed": 1})
@@ -376,6 +385,25 @@ def test_async_fixture(testdir, cmd_opts):
     assert_outcomes(rr, {"passed": 2, "failed": 1})
 
 
+@skip_if_no_async_await()
+def test_async_fixture_no_arguments(testdir, cmd_opts, empty_optional_call):
+    test_file = """
+    from twisted.internet import reactor, defer
+    import pytest
+    import pytest_twisted
+    
+    @pytest_twisted.async_fixture{optional_call}
+    async def scope(request):
+        return request.scope
+
+    def test_is_function_scope(scope):
+        assert scope == "function"
+    """.format(optional_call=empty_optional_call)
+    testdir.makepyfile(test_file)
+    rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
+    assert_outcomes(rr, {"passed": 1})
+
+
 @skip_if_no_async_generators()
 def test_async_yield_fixture_concurrent_teardown(testdir, cmd_opts):
     test_file = """
@@ -451,6 +479,29 @@ def test_async_yield_fixture(testdir, cmd_opts):
     rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
     # TODO: this is getting super imprecise...
     assert_outcomes(rr, {"passed": 4, "failed": 1, "errors": 2})
+
+
+@skip_if_no_async_generators()
+def test_async_yield_fixture_no_arguments(
+        testdir,
+        cmd_opts,
+        empty_optional_call,
+):
+    test_file = """
+    from twisted.internet import reactor, defer
+    import pytest
+    import pytest_twisted
+    
+    @pytest_twisted.async_yield_fixture{optional_call}
+    async def scope(request):
+        yield request.scope
+
+    def test_is_function_scope(scope):
+        assert scope == "function"
+    """.format(optional_call=empty_optional_call)
+    testdir.makepyfile(test_file)
+    rr = testdir.run(sys.executable, "-m", "pytest", "-v", *cmd_opts)
+    assert_outcomes(rr, {"passed": 1})
 
 
 @skip_if_no_async_generators()

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -391,7 +391,7 @@ def test_async_fixture_no_arguments(testdir, cmd_opts, empty_optional_call):
     from twisted.internet import reactor, defer
     import pytest
     import pytest_twisted
-    
+
     @pytest_twisted.async_fixture{optional_call}
     async def scope(request):
         return request.scope
@@ -491,7 +491,7 @@ def test_async_yield_fixture_no_arguments(
     from twisted.internet import reactor, defer
     import pytest
     import pytest_twisted
-    
+
     @pytest_twisted.async_yield_fixture{optional_call}
     async def scope(request):
         yield request.scope


### PR DESCRIPTION
I give in...

Draft for:
- [x] It's built on top of #91...
- Switching to `@decorator.decorator`
  - nope, that's off by a layer since we presently need marks on the test function.