### PR TITLE
Stop excluding py39 on win32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,6 @@ jobs:
               implementation: pypy
             reactor:
               tox: pyside2
-          - python:
-              tox: py39
-            os:
-              python_platform: win32
     steps:
       - uses: actions/checkout@v2
       - name: Enable Problem Matchers


### PR DESCRIPTION
Twisted 21.2.0 supports Python 3.9 on Windows