### PR TITLE
avoid twisted installing a SIGINT handler

### DIFF
--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import itertools
+import signal
 import sys
 import warnings
 
@@ -199,9 +200,9 @@ def init_twisted_greenlet():
         return
 
     if not _instances.reactor.running:
-        _instances.gr_twisted = greenlet.greenlet(
-            lambda: _instances.reactor.run(installSignalHandlers=False),
-        )
+        if signal.getsignal(signal.SIGINT) == signal.default_int_handler:
+            signal.signal(signal.SIGINT, functools.partial(signal.default_int_handler))
+        _instances.gr_twisted = greenlet.greenlet(_instances.reactor.run)
         # give me better tracebacks:
         failure.Failure.cleanFailure = lambda self: None
     else:

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -201,7 +201,10 @@ def init_twisted_greenlet():
 
     if not _instances.reactor.running:
         if signal.getsignal(signal.SIGINT) == signal.default_int_handler:
-            signal.signal(signal.SIGINT, functools.partial(signal.default_int_handler))
+            signal.signal(
+                signal.SIGINT,
+                functools.partial(signal.default_int_handler),
+            )
         _instances.gr_twisted = greenlet.greenlet(_instances.reactor.run)
         # give me better tracebacks:
         failure.Failure.cleanFailure = lambda self: None

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -199,7 +199,9 @@ def init_twisted_greenlet():
         return
 
     if not _instances.reactor.running:
-        _instances.gr_twisted = greenlet.greenlet(_instances.reactor.run)
+        _instances.gr_twisted = greenlet.greenlet(
+            lambda: _instances.reactor.run(installSignalHandlers=False),
+        )
         # give me better tracebacks:
         failure.Failure.cleanFailure = lambda self: None
     else:

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -875,6 +875,7 @@ def test_wrong_reactor_with_qt5reactor(testdir, cmd_opts, request):
 
 
 def test_pytest_from_reactor_thread(testdir, cmd_opts, request):
+    return
     skip_if_reactor_not(request, "default")
     test_file = """
     import pytest
@@ -1158,8 +1159,11 @@ def test_sigint_for_regular_tests(testdir, cmd_opts):
     """
     testdir.makepyfile(test_file)
     rr = testdir.run(*cmd_opts, timeout=timeout)
-    assert_outcomes(rr, {})
-    rr.stdout.re_match_lines(lines2=[r".* no tests ran in .*"])
+    if sys.platform != "win32":
+        # on Windows pytest isn't even reporting the status, just stopping...
+        assert_outcomes(rr, {})
+        rr.stdout.re_match_lines(lines2=[r".* no tests ran in .*"])
+    rr.stdout.no_re_match_line(pat=r".*test_should_not_run.*")
 
 
 def test_sigint_for_inline_callbacks_tests(testdir, cmd_opts):
@@ -1188,5 +1192,8 @@ def test_sigint_for_inline_callbacks_tests(testdir, cmd_opts):
     """
     testdir.makepyfile(test_file)
     rr = testdir.run(*cmd_opts, timeout=timeout)
-    assert_outcomes(rr, {})
-    rr.stdout.re_match_lines(lines2=[r".* no tests ran in .*"])
+    if sys.platform != "win32":
+        # on Windows pytest isn't even reporting the status, just stopping...
+        assert_outcomes(rr, {})
+        rr.stdout.re_match_lines(lines2=[r".* no tests ran in .*"])
+    rr.stdout.no_re_match_line(pat=r".*test_should_not_run.*")

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import textwrap
 
@@ -11,6 +12,8 @@ ASYNC_AWAIT = sys.version_info >= (3, 5)
 ASYNC_GENERATORS = sys.version_info >= (3, 6)
 
 timeout = 15
+
+pytest_version = tuple(int(segment) for segment in pytest.__version__.split(".")[:3])
 
 
 # https://github.com/pytest-dev/pytest/issues/6505
@@ -1163,7 +1166,13 @@ def test_sigint_for_regular_tests(testdir, cmd_opts):
         # on Windows pytest isn't even reporting the status, just stopping...
         assert_outcomes(rr, {})
         rr.stdout.re_match_lines(lines2=[r".* no tests ran in .*"])
-    rr.stdout.no_re_match_line(pat=r".*test_should_not_run.*")
+
+    pattern = r".*test_should_not_run.*"
+
+    if pytest_version >= (5, 3, 0):
+        rr.stdout.no_re_match_line(pat=pattern)
+    else:
+        assert re.match(pattern, rr.stdout.str()) is None
 
 
 def test_sigint_for_inline_callbacks_tests(testdir, cmd_opts):
@@ -1196,4 +1205,10 @@ def test_sigint_for_inline_callbacks_tests(testdir, cmd_opts):
         # on Windows pytest isn't even reporting the status, just stopping...
         assert_outcomes(rr, {})
         rr.stdout.re_match_lines(lines2=[r".* no tests ran in .*"])
-    rr.stdout.no_re_match_line(pat=r".*test_should_not_run.*")
+
+    pattern = r".*test_should_not_run.*"
+
+    if pytest_version >= (5, 3, 0):
+        rr.stdout.no_re_match_line(pat=pattern)
+    else:
+        assert re.match(pattern, rr.stdout.str()) is None

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -13,7 +13,10 @@ ASYNC_GENERATORS = sys.version_info >= (3, 6)
 
 timeout = 15
 
-pytest_version = tuple(int(segment) for segment in pytest.__version__.split(".")[:3])
+pytest_version = tuple(
+    int(segment)
+    for segment in pytest.__version__.split(".")[:3]
+)
 
 
 # https://github.com/pytest-dev/pytest/issues/6505

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -882,7 +882,6 @@ def test_wrong_reactor_with_qt5reactor(testdir, cmd_opts, request):
 
 
 def test_pytest_from_reactor_thread(testdir, cmd_opts, request):
-    return
     skip_if_reactor_not(request, "default")
     test_file = """
     import pytest


### PR DESCRIPTION
When pytest is sent a `SIGINT` it stops running tests.  Except when pytest-twisted is active.  Then it aborts the active test and continues through the rest of them failing each one at a time.  I believe that Twisted is capturing the `SIGINT` and not letting it propogate to pytest.  When the reactor stops itself then it isn't available to the rest of the tests and they fail.

https://github.com/pytest-dev/pytest-twisted/pull/137#issuecomment-888425804

Draft for:
- [x] self reflection
- [x] how might this mess with existing test suites