### PR TITLE
add test for shutdown event callbacks

### DIFF
--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1148,6 +1148,7 @@ def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
 
     test_file = """
     import os
+    import signal
 
     import pytest_twisted
 
@@ -1160,7 +1161,7 @@ def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
         reactor.addSystemEventTrigger(phase={phase!r}, eventType={event!r}, callable=output_stuff)
 
         if {kill!r}:
-            os.kill(os.get_pid())
+            os.kill(os.getpid(), signal.SIGINT)
 
         yield
     """.format(kill=kill, event=event, phase=phase, test_string=test_string)

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1170,5 +1170,4 @@ def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
     """.format(kill=kill, event=event, phase=phase, test_string=test_string)
     testdir.makepyfile(test_file)
     rr = testdir.run(*cmd_opts, timeout=timeout)
-    assert_outcomes(rr, {"passed": 1})
     rr.stdout.fnmatch_lines(lines2=[test_string])

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1141,14 +1141,6 @@ def test_import_pytest_twisted_in_conftest_py_not_a_problem(testdir, cmd_opts):
     assert_outcomes(rr, {"passed": 1})
 
 
-@pytest.mark.xfail(
-    condition=(
-        sys.platform == "win32"
-        or os.environ.get("REACTOR", "").startswith("qt")
-    ),
-    reason="Needs handled on Windows and with qt5reactor.",
-    strict=True,
-)
 @pytest.mark.parametrize(argnames="kill", argvalues=[False, True])
 @pytest.mark.parametrize(argnames="event", argvalues=["shutdown"])
 @pytest.mark.parametrize(
@@ -1156,6 +1148,13 @@ def test_import_pytest_twisted_in_conftest_py_not_a_problem(testdir, cmd_opts):
     argvalues=["before", "during", "after"],
 )
 def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
+    is_win32 = sys.platform == "win32"
+    is_qt = os.environ.get("REACTOR", "").startswith("qt")
+    is_kill = kill
+
+    if (is_win32 or is_qt) and is_kill:
+        pytest.xfail(reason="Needs handled on Windows and with qt5reactor.")
+
     test_string = "1kljgf90u0lkj13l4jjklsfdo89898y24hlkjalkjs38"
 
     test_file = """

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1147,6 +1147,7 @@ def test_import_pytest_twisted_in_conftest_py_not_a_problem(testdir, cmd_opts):
         or os.environ.get("REACTOR", "").startswith("qt")
     ),
     reason="Needs handled on Windows and with qt5reactor.",
+    strict=True,
 )
 @pytest.mark.parametrize(argnames="kill", argvalues=[False, True])
 @pytest.mark.parametrize(argnames="event", argvalues=["shutdown"])

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import textwrap
 
@@ -1140,6 +1141,13 @@ def test_import_pytest_twisted_in_conftest_py_not_a_problem(testdir, cmd_opts):
     assert_outcomes(rr, {"passed": 1})
 
 
+@pytest.mark.xfail(
+    condition=(
+        sys.platform == "win32"
+        or os.environ.get("REACTOR", "").startswith("qt")
+    ),
+    reason="Needs handled on Windows and with qt5reactor.",
+)
 @pytest.mark.parametrize(argnames="kill", argvalues=[False, True])
 @pytest.mark.parametrize(argnames="event", argvalues=["shutdown"])
 @pytest.mark.parametrize(

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1161,11 +1161,7 @@ def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
     @pytest_twisted.inlineCallbacks
     def test_succeed():
         from twisted.internet import reactor
-        reactor.addSystemEventTrigger(
-            phase={phase!r},
-            eventType={event!r},
-            callable=output_stuff,
-        )
+        reactor.addSystemEventTrigger({phase!r}, {event!r}, output_stuff)
 
         if {kill!r}:
             os.kill(os.getpid(), signal.SIGINT)

--- a/testing/test_basic.py
+++ b/testing/test_basic.py
@@ -1142,7 +1142,10 @@ def test_import_pytest_twisted_in_conftest_py_not_a_problem(testdir, cmd_opts):
 
 @pytest.mark.parametrize(argnames="kill", argvalues=[False, True])
 @pytest.mark.parametrize(argnames="event", argvalues=["shutdown"])
-@pytest.mark.parametrize(argnames="phase", argvalues=["before", "during", "after"])
+@pytest.mark.parametrize(
+    argnames="phase",
+    argvalues=["before", "during", "after"],
+)
 def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
     test_string = "1kljgf90u0lkj13l4jjklsfdo89898y24hlkjalkjs38"
 
@@ -1158,7 +1161,11 @@ def test_addSystemEventTrigger(testdir, cmd_opts, kill, event, phase):
     @pytest_twisted.inlineCallbacks
     def test_succeed():
         from twisted.internet import reactor
-        reactor.addSystemEventTrigger(phase={phase!r}, eventType={event!r}, callable=output_stuff)
+        reactor.addSystemEventTrigger(
+            phase={phase!r},
+            eventType={event!r},
+            callable=output_stuff,
+        )
 
         if {kill!r}:
             os.kill(os.getpid(), signal.SIGINT)


### PR DESCRIPTION
Draft for:
- [x] ~~Make it actually handle shutdown event callbacks in case of `SIGINT`.~~
  - Or just xfail it according to present behavior and deal with it later.