### PR TITLE
Avoid setting signals when not in main thread (and warn)

### DIFF
--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -204,8 +204,10 @@ def init_twisted_greenlet():
         if not isinstance(threading.current_thread(), threading._MainThread):
             warnings.warn(
                 (
-                    'Failed to block Twisted signal configuration due to not running in the main thread.'
-                    '  See https://github.com/pytest-dev/pytest-twisted/issues/153.'
+1234567890123456789012345678901234567890123456789012345678901234567890123456789
+                    'Failed to block Twisted signal configuration due to not'
+                    ' running in the main thread.  See'
+                    ' https://github.com/pytest-dev/pytest-twisted/issues/153.'
 
                 ),
                 RuntimeWarning,

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -204,8 +204,8 @@ def init_twisted_greenlet():
         if not isinstance(threading.current_thread(), threading._MainThread):
             warnings.warn(
                 (
-                    'Failed to block Twisted signal configuration due to not'
-                    ' running in the main thread.  See'
+                    'Will not attempt to block Twisted signal configuration'
+                    ' since we are not running in the main thread.  See'
                     ' https://github.com/pytest-dev/pytest-twisted/issues/153.'
                 ),
                 RuntimeWarning,

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -204,11 +204,9 @@ def init_twisted_greenlet():
         if not isinstance(threading.current_thread(), threading._MainThread):
             warnings.warn(
                 (
-1234567890123456789012345678901234567890123456789012345678901234567890123456789
                     'Failed to block Twisted signal configuration due to not'
                     ' running in the main thread.  See'
                     ' https://github.com/pytest-dev/pytest-twisted/issues/153.'
-
                 ),
                 RuntimeWarning,
             )

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -3,6 +3,7 @@ import inspect
 import itertools
 import signal
 import sys
+import threading
 import warnings
 
 import decorator

--- a/pytest_twisted.py
+++ b/pytest_twisted.py
@@ -200,7 +200,16 @@ def init_twisted_greenlet():
         return
 
     if not _instances.reactor.running:
-        if signal.getsignal(signal.SIGINT) == signal.default_int_handler:
+        if not isinstance(threading.current_thread(), threading._MainThread):
+            warnings.warn(
+                (
+                    'Failed to block Twisted signal configuration due to not running in the main thread.'
+                    '  See https://github.com/pytest-dev/pytest-twisted/issues/153.'
+
+                ),
+                RuntimeWarning,
+            )
+        elif signal.getsignal(signal.SIGINT) == signal.default_int_handler:
             signal.signal(
                 signal.SIGINT,
                 functools.partial(signal.default_int_handler),


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-twisted/issues/153

Draft for:
- [x] May also need to tell twisted to totally avoid setting signal handling.
  - based on user testing, nope