### PR TITLE
Disable PyPy 2.7 CI due to installation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,13 @@ jobs:
             docker: "3.10"
             implementation: cpython
             major: 3
-          - name: PyPy 2.7
-            tox: pypy27
-            action: pypy-2.7
-            docker: pypy2.7
-            implementation: pypy
-            major: 2
+# disabled due to installation failures
+#           - name: PyPy 2.7
+#             tox: pypy27
+#             action: pypy-2.7
+#             docker: pypy2.7
+#             implementation: pypy
+#             major: 2
           - name: PyPy 3.7
             tox: pypy37
             action: pypy-3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
             implementation: cpython
             major: 3
 # disabled due to installation failures
+# https://github.com/pytest-dev/pytest-twisted/pull/157
 #           - name: PyPy 2.7
 #             tox: pypy27
 #             action: pypy-2.7


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:52
```python-traceback
Collecting twisted
  Downloading Twisted-20.3.0.tar.bz2 (3.1 MB)
    ERROR: Command errored out with exit status 1:
     command: /Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy27-defaultreactor/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/[24](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:25)/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-install-PghqCv/twisted/setup.py'"'"'; __file__='"'"'/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-install-PghqCv/twisted/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-pip-egg-info-3oAGXs
         cwd: /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-install-PghqCv/twisted/
    Complete output (23 lines):
    Traceback (most recent call last):
      File "<module>", line 1, in <module>
      File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-install-PghqCv/twisted/setup.py", line 20, in <module>
        setuptools.setup(**_setup["getSetupArgs"]())
      File "/Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy[27](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:28)-defaultreactor/site-packages/setuptools/__init__.py", line 162, in setup
        return distutils.core.setup(**attrs)
      File "/Users/runner/hostedtoolcache/PyPy/2.7.18/x64/lib-python/2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy27-defaultreactor/site-packages/setuptools/dist.py", line 448, in __init__
        k: v for k, v in attrs.items()
      File "/Users/runner/hostedtoolcache/PyPy/2.7.18/x64/lib-python/2.7/distutils/dist.py", line [28](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:29)7, in __init__
        self.finalize_options()
      File "/Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy27-defaultreactor/site-packages/setuptools/dist.py", line 7[40](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:41), in finalize_options
        ep(self)
      File "/Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy27-defaultreactor/site-packages/setuptools/dist.py", line 747, in _finalize_setup_keywords
        ep.load()(self, ep.name, value)
      File "/Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy27-defaultreactor/site-packages/pkg_resources/__init__.py", line 24[43](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:44), in load
        return self.resolve()
      File "/Users/runner/work/pytest-twisted/pytest-twisted/.tox/pypy27-defaultreactor/site-packages/pkg_resources/__init__.py", line 2[44](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:45)9, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
      File "/private/var/folders/24/8k[48](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:49)jl6d2[49](https://github.com/pytest-dev/pytest-twisted/actions/runs/3485746909/jobs/5831552488#step:8:50)_n_qfxwsl6xvm0000gn/T/pip-install-PghqCv/twisted/.eggs/incremental-22.10.0-py2.7.egg/incremental/__init__.py", line 14, in <module>
        from typing import TYPE_CHECKING, Any, TypeVar, Union, Optional, Dict
    ImportError: No module named typing
```

Installing twisted 20.3.0 via tox under  PyPy 2.7 fails.  In twisted we've got a `setup_requires` for incremental https://github.com/twisted/twisted/blob/twisted-20.3.0/src/twisted/python/_setup.py#L286 and that's handled but it isn't installing the typing module that incremental depends on. https://github.com/twisted/incremental/blob/19a308d70d72d0aa95380125988d60abb23b64e3/setup.cfg#L24